### PR TITLE
Dehardcode compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
-CFLAGS=-O3 --std=gnu++11
-LFLAGS=-s -lpng
+CFLAGS+= -O3 --std=gnu++11
+LFLAGS+= -s -lpng
 SRCD = source
 SRC = $(wildcard $(SRCD)/*.cpp)
 OBJD = obj
 OBJ = $(patsubst $(SRCD)/%.cpp,$(OBJD)/%.o,$(SRC))
 TSTD = tests
-INSTALL_PATH=/usr/local
+PREFIX?=/usr/local
+target=$(DESTDIR)$(PREFIX)
 
 $(shell mkdir -p $(OBJD) >/dev/null)
 
@@ -34,10 +35,10 @@ clean-test:
 	@$(MAKE) --silent -C $(TSTD)/ clean
 
 install: bfk
-	@install -m 0755 bfk $(INSTALL_PATH)/bin/
+	@install -m 0755 bfk $(target)/bin
 
 remove:
-	@rm -fv $(INSTALL_PATH)/bin/bfk
+	@rm -fv $(target)/bin/bfk
 
 test: bfk
 	@sync bfk
@@ -56,4 +57,3 @@ help:
 	@echo "make remove     : Uninstalls the program"
 	@echo "make clean      : Erases any compilation or testing generated files"
 	@echo "make clean-test : Erases only testing generated files"
-

--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,15 @@ $(shell mkdir -p $(OBJD) >/dev/null)
 
 bfk: $(OBJD) $(OBJ)
 	@echo Linking: $@
-	$(CXX) -o bfk $(OBJ) $(LFLAGS)
+	@$(CXX) -o bfk $(OBJ) $(LFLAGS)
 
 $(OBJD)/%.o: $(SRCD)/%.cpp
 	@echo Compiling: $(<F)
-	$(CXX) $(CFLAGS) -c -o $@ $<
+	@$(CXX) $(CFLAGS) -c -o $@ $<
 
 $(OBJD)/%.d: $(SRCD)/%.cpp
 	@set -e; rm -f $@; \
-	$(CXX) --std=gnu++11 -MM -MT $(OBJD)/$(*F).o $(CPPFLAGS) $< > $@.$$$$; \
+	@$(CXX) --std=gnu++11 -MM -MT $(OBJD)/$(*F).o $(CPPFLAGS) $< > $@.$$$$; \
 	sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' < $@.$$$$ > $@; \
 	rm -f $@.$$$$
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ $(OBJD)/%.o: $(SRCD)/%.cpp
 
 $(OBJD)/%.d: $(SRCD)/%.cpp
 	@set -e; rm -f $@; \
-	@$(CXX) --std=gnu++11 -MM -MT $(OBJD)/$(*F).o $(CPPFLAGS) $< > $@.$$$$; \
+	$(CXX) --std=gnu++11 -MM -MT $(OBJD)/$(*F).o $(CPPFLAGS) $< > $@.$$$$; \
 	sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' < $@.$$$$ > $@; \
 	rm -f $@.$$$$
 

--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,15 @@ $(shell mkdir -p $(OBJD) >/dev/null)
 
 bfk: $(OBJD) $(OBJ)
 	@echo Linking: $@
-	@g++ -o bfk $(OBJ) $(LFLAGS)
+	$(CXX) -o bfk $(OBJ) $(LFLAGS)
 
 $(OBJD)/%.o: $(SRCD)/%.cpp
 	@echo Compiling: $(<F)
-	@g++ $(CFLAGS) -c -o $@ $<
+	$(CXX) $(CFLAGS) -c -o $@ $<
 
 $(OBJD)/%.d: $(SRCD)/%.cpp
 	@set -e; rm -f $@; \
-	g++ --std=gnu++11 -MM -MT $(OBJD)/$(*F).o $(CPPFLAGS) $< > $@.$$$$; \
+	$(CXX) --std=gnu++11 -MM -MT $(OBJD)/$(*F).o $(CPPFLAGS) $< > $@.$$$$; \
 	sed 's,\($*\)\.o[ :]*,\1.o $@ : ,g' < $@.$$$$ > $@; \
 	rm -f $@.$$$$
 


### PR DESCRIPTION
It is generally nicer to not hard code the compiler so that the Makefile works in more use cases e.g. cross compiling, systems that have clang installed and so on.  `g++` can be replaced with `$(CXX)`; `$(CXX)` will default to `g++` if not set.